### PR TITLE
Welcome page and Pro notice fixes

### DIFF
--- a/includes/arconix-shortcodes-all-component.php
+++ b/includes/arconix-shortcodes-all-component.php
@@ -54,16 +54,22 @@ if ( ! class_exists( 'Arconix_Shortcodes_Component' ) ) {
 
                 new Shortcodes_TS_Tracker ( $shortcodes_plugin_prefix, $shortcodes_plugin_name );
 
-                $shortcodes_deativate = new Shortcodes_TS_deactivate;
-                $shortcodes_deativate->init ( $shortcodes_file_name, $shortcodes_plugin_name );
+                // $shortcodes_deativate = new Shortcodes_TS_deactivate;
+                // $shortcodes_deativate->init ( $shortcodes_file_name, $shortcodes_plugin_name );
                 
-                new Shortcodes_TS_Welcome ( $shortcodes_plugin_name, $shortcodes_plugin_prefix, $shortcodes_locale, $shortcodes_plugin_folder_name, $shortcodes_plugin_dir_name, $shortcodes_get_previous_version );
+                $user = wp_get_current_user();
+                
+                if ( in_array( 'administrator', (array) $user->roles ) ) {
+                    new Shortcodes_TS_Welcome ( $shortcodes_plugin_name, $shortcodes_plugin_prefix, $shortcodes_locale, $shortcodes_plugin_folder_name, $shortcodes_plugin_dir_name, $shortcodes_get_previous_version );
+                }
 
                 $ts_pro_shortcodes = self::shortcodes_get_faq ();
                 new Shortcodes_TS_Faq_Support( $shortcodes_plugin_name, $shortcodes_plugin_prefix, $shortcodes_plugins_page, $shortcodes_locale, $shortcodes_plugin_folder_name, $shortcodes_plugin_slug, $ts_pro_shortcodes, '', $shortcodes_file_name );
                 
-                $ts_pro_notices = self::shortcodes_get_notice_text ();
-				new Shortcodes_ts_pro_notices( $shortcodes_plugin_name, $shortcodes_lite_plugin_prefix, $shortcodes_plugin_prefix, $ts_pro_notices, $shortcodes_file_name, $shortcodes_pro_file_name );
+                if ( in_array('woocommerce/woocommerce.php', get_option('active_plugins') ) ) {
+                    $ts_pro_notices = self::shortcodes_get_notice_text ();
+                    new Shortcodes_ts_pro_notices( $shortcodes_plugin_name, $shortcodes_lite_plugin_prefix, $shortcodes_plugin_prefix, $ts_pro_notices, $shortcodes_file_name, $shortcodes_pro_file_name );
+                }
 
             }
         }

--- a/includes/arconix-shortcodes-all-component.php
+++ b/includes/arconix-shortcodes-all-component.php
@@ -54,8 +54,8 @@ if ( ! class_exists( 'Arconix_Shortcodes_Component' ) ) {
 
                 new Shortcodes_TS_Tracker ( $shortcodes_plugin_prefix, $shortcodes_plugin_name );
 
-                // $shortcodes_deativate = new Shortcodes_TS_deactivate;
-                // $shortcodes_deativate->init ( $shortcodes_file_name, $shortcodes_plugin_name );
+                $shortcodes_deativate = new Shortcodes_TS_deactivate;
+                $shortcodes_deativate->init ( $shortcodes_file_name, $shortcodes_plugin_name );
                 
                 $user = wp_get_current_user();
                 

--- a/includes/component/welcome-page/ts-welcome.php
+++ b/includes/component/welcome-page/ts-welcome.php
@@ -92,6 +92,9 @@ class Shortcodes_TS_Welcome {
 		self::$plugin_folder    	  = $ts_plugin_folder_name;
 		self::$plugin_file_path       = $ts_plugin_dir_name;
 		
+		add_action( 'admin_init', array( &$this, 'ts_add_plugin_active_check' ),1 );
+
+		register_deactivation_hook( self::$plugin_file_path, array( &$this, 'ts_delete_plugin_from_active_check' ) );
 
 		//Update plugin
 		add_action( 'admin_init', array( &$this, 'ts_update_db_check' ) );
@@ -109,6 +112,30 @@ class Shortcodes_TS_Welcome {
 		self::$previous_plugin_version = $ts_previous_version;
 		self::$plugin_url     		   = $this->ts_get_plugin_url();
 		self::$template_base  		   = $this->ts_get_template_path();
+	}
+
+	function ts_delete_plugin_from_active_check ( ){
+
+		$active_ts_plugins = get_option( 'active_TS_plugins', array() );
+		if ( in_array ( self::$plugin_name , $active_ts_plugins) ){
+
+			$ts_plugin_name = array ( self::$plugin_name );
+			
+			$updated_activated_ts_plugins = array_diff( $active_ts_plugins, $ts_plugin_name );
+			update_option( 'active_TS_plugins', $updated_activated_ts_plugins );
+		}
+	}
+
+	function ts_add_plugin_active_check () {
+
+		$active_ts_plugins = get_option( 'active_TS_plugins', array() );
+
+		if ( !in_array ( self::$plugin_name , $active_ts_plugins) ){
+
+			$active_ts_plugins [] = self::$plugin_name;
+			
+			update_option( 'active_TS_plugins', $active_ts_plugins );
+		}
 	}
 
 	/**
@@ -263,9 +290,16 @@ class Shortcodes_TS_Welcome {
 			return;
 		}
 
-		if( !get_option( self::$plugin_prefix . '_pro_welcome_page_shown' ) ) {
-			wp_safe_redirect( admin_url( 'index.php?page=' . self::$plugin_prefix . '-pro-about' ) );
-			exit;
+		$active_ts_plugins = get_option( 'active_TS_plugins', array() );
+
+		/**
+		 * This count of active plugins indicate that we will not redirect to the welcome page when there are more than 2 of our plugins are activated.
+		 */
+		if( count ( $active_ts_plugins ) == 1 ) {
+			if( !get_option( self::$plugin_prefix . '_pro_welcome_page_shown' ) ) {
+				wp_safe_redirect( admin_url( 'index.php?page=' . self::$plugin_prefix . '-pro-about' ) );
+				exit;
+			}
 		}
 	}
 

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://www.tychesoftwares.com/
  * Description: A handy collection of shortcodes for your site.
  *
- * Version: 2.1.4
+ * Version: 2.1.5
  *
  * Author: Tyche Softwares
  * Author URI: https://www.tychesoftwares.com/
@@ -27,7 +27,7 @@ class Arconix_Shortcodes {
      * @access  private
      * @var     string		$version		Current plugin version
      */
-    const VERSION = '2.1.4';
+    const VERSION = '2.1.5'; 
 
     /**
      * The url path to this plugin.
@@ -60,13 +60,16 @@ class Arconix_Shortcodes {
         $is_admin = is_admin();
 
         if ( true === $is_admin ) {
-            require_once( plugin_dir_path(__FILE__) . 'includes/arconix-shortcodes-all-component.php' );
-
+            add_action( 'init',                         array ($this , 'shortcodes_load_files') );
             add_filter( 'ts_deativate_plugin_questions', array( $this, 'shortcodes_deactivate_add_questions' ), 10, 1 );
             add_filter( 'ts_tracker_data',               array( $this, 'shortcodes_ts_add_plugin_tracking_data' ), 10, 1 );
             add_filter( 'ts_tracker_opt_out_data',       array( $this, 'shortcodes_get_data_for_opt_out' ), 10, 1 );
             add_action( 'admin_init',                    array( $this, 'shortcodes_admin_actions' ) );
         }
+    }
+
+    function shortcodes_load_files () {
+        require_once( plugin_dir_path(__FILE__) . 'includes/arconix-shortcodes-all-component.php' );
     }
 
     /**
@@ -199,7 +202,7 @@ class Arconix_Shortcodes {
         if( ! $shortcodes or ! is_array( $shortcodes ) )
             return;
 
-        $return = '<p><a href="http://arcnx.co/aswiki"><img src="' . $this->url . 'images/admin/page-16x16.png">Documentation</a></p><ul>';
+        $return = '<p><a href="https://www.tychesoftwares.com/docs/docs/shortcodes/shortcode-reference/"><img src="' . $this->url . 'images/admin/page-16x16.png">Documentation</a></p><ul>';
         foreach( (array) $shortcodes as $shortcode ) {
             $return .= '<li>[' . $shortcode . ']</li>';
         }

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: jgardner03, tychesoftwares, bhavik.kiri
 Donate link: http://arcnx.co/acsdonation
 Tags: arconix, shortcodes, tabs, toggle, buttons, accordion
 Requires at least: 4.3
-Tested up to: 4.9.1
-Stable tag: 2.1.4
+Tested up to: 4.9.8
+Stable tag: 2.1.5
 License: GPLv2 or later
 
 Arconix Shortcodes provides a number of useful design elements like buttons, boxes, tabs and toggles to help compliment any website.
@@ -121,6 +121,9 @@ That's fantastic! Feel free to submit a pull request over at [Github](http://arc
 4. Unordered list styles
 
 == Changelog == 
+
+= 2.1.5 =
+* The documentation link on the page & post page was wrong. It has been redorected to correct link.
 
 = 2.1.4 =
 * Usage Tracking has been added in the plugin. It provides an option to allow tracking of the non-sensitive data of our plugin from the website. You can read more about it [here](https://www.tychesoftwares.com/docs/docs/shortcodes/usage-tracking/).


### PR DESCRIPTION
This fix ensures that it will show pro plugins notices only when the WC is active in the customer's site.

The welcome page will be displayed only for admin users, other users it will be not displayed.

Now, if there are 2 or more than that our plugins are active on customers site then We will not display welcome page. As it was causing the infinite loop of the welcome page.